### PR TITLE
Update for local development builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Xcode .gitignore
+#
+# Source:
+# https://github.com/github/gitignore/blob/master/Global/Xcode.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Gcc Patch
+/*.gcno
+
+## Sample Data
+.assets/*.csv
+
+## Secrets
+Generated
+Secrets.xcconfig
+DeveloperSettings.xcconfig
+Data/export.xml
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+"swiftlint"

--- a/HKImport.xcodeproj/project.pbxproj
+++ b/HKImport.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		4C8BA0091FB1EA45007C2D4F /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		4DFB0F16247DB00B00D61E7F /* HKWorkoutActivityType+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HKWorkoutActivityType+Name.swift"; sourceTree = "<group>"; };
 		4DFB0F18247E164200D61E7F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		DE322590273ED87E00E02BC1 /* HKImportConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = HKImportConfig.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +79,7 @@
 				4C8B9FDE1FB1D757007C2D4F /* LaunchScreen.storyboard */,
 				4C8B9FD61FB1D757007C2D4F /* Main.storyboard */,
 				4C8B9FD41FB1D757007C2D4F /* ViewController.swift */,
+				DE322590273ED87E00E02BC1 /* HKImportConfig.xcconfig */,
 			);
 			path = HKImport;
 			sourceTree = "<group>";
@@ -189,7 +191,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n/opt/homebrew/bin/swiftlint\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nswiftlint\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -230,6 +232,7 @@
 /* Begin XCBuildConfiguration section */
 		4C8B9FF81FB1D757007C2D4F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DE322590273ED87E00E02BC1 /* HKImportConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -290,6 +293,7 @@
 		};
 		4C8B9FF91FB1D757007C2D4F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DE322590273ED87E00E02BC1 /* HKImportConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -343,14 +347,13 @@
 		};
 		4C8B9FFB1FB1D757007C2D4F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DE322590273ED87E00E02BC1 /* HKImportConfig.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = HKImport/HKImport.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Q25LVLEHFB;
 				INFOPLIST_FILE = HKImport/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.entire.hkimport;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ORGANIZATION_IDENTIFIER).hkimport";
 				PRODUCT_NAME = HKImport;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -362,11 +365,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = HKImport/HKImport.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Q25LVLEHFB;
 				INFOPLIST_FILE = HKImport/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.entire.hkimport;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ORGANIZATION_IDENTIFIER).hkimport";
 				PRODUCT_NAME = HKImport;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/HKImport/HKImportConfig.xcconfig
+++ b/HKImport/HKImportConfig.xcconfig
@@ -1,0 +1,8 @@
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+DEVELOPMENT_TEAM = Q25LVLEHFB
+CODE_SIGN_IDENTITY = Apple Development
+CODE_SIGN_STYLE = Automatic
+ORGANIZATION_IDENTIFIER = io.entire
+
+#include? "../DeveloperSettings.xcconfig"

--- a/README.md
+++ b/README.md
@@ -15,3 +15,42 @@ Not all HealthKit record types are supported.
 ## Origin
 
 This repository was forked from [HealthKitImporter](https://github.com/Comocomo/HealthKitImporter).
+
+#### Building
+
+HKImport relies on [swiftlint](https://realm.github.io/SwiftLint/). Itcan be installed 
+via [homebrew](https://brew.sh) via the provided `Brewfile` by running `brew bundle`
+or manually.
+
+You can locally override the Xcode settings for code signing
+by creating a `DeveloperSettings.xcconfig` file locally at the root of the project directory.
+This allows for a pristine project with code signing set up with the appropriate
+developer ID and certificates, and for developer to be able to have local settings
+without needing to check in anything into source control.
+
+You can do this in one of two ways: using the included `setup.sh` script or by creating the folder structure and file manually.
+
+##### Using `setup.sh`
+
+- Open Terminal and `cd` into the project directory. 
+- Run this command to ensure you have execution rights for the script: `chmod +x setup.sh`
+- Execute the script with the following command: `./setup.sh` and complete the answers.
+
+##### Manually 
+
+Create a plain text file in it: `DeveloperSettings.xcconfig` and
+give it the contents:
+
+```
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = <Your Team ID>
+CODE_SIGN_STYLE = Automatic
+ORGANIZATION_IDENTIFIER = <Your Domain Name Reversed>
+```
+
+Set `DEVELOPMENT_TEAM` to your Apple supplied development team.  You can use Keychain
+Access to [find your development team ID](/Technotes/FindingYourDevelopmentTeamID.md).
+Set `ORGANIZATION_IDENTIFIER` to a reversed domain name that you control or have made up.
+
+Now you should be able to build without code signing errors and without modifying
+the project.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+cat << "EOF"
+ __    __   __  ___  __  .___  ___. .______     ______   .______     .___________.
+|  |  |  | |  |/  / |  | |   \/   | |   _  \   /  __  \  |   _  \    |           |
+|  |__|  | |  '  /  |  | |  \  /  | |  |_)  | |  |  |  | |  |_)  |   `---|  |----`
+|   __   | |    <   |  | |  |\/|  | |   ___/  |  |  |  | |      /        |  |     
+|  |  |  | |  .  \  |  | |  |  |  | |  |      |  `--'  | |  |\  \----.   |  |     
+|__|  |__| |__|\__\ |__| |__|  |__| | _|       \______/  | _| `._____|   |__|     
+                                                                                  
+
+EOF
+
+echo This script will create a DeveloperSettings.xcconfig file.
+echo 
+echo We need to ask a few questions first.
+echo 
+read -p "Press enter to get started."
+
+
+# Get the user's Developer Team ID
+echo 1. What is your Developer Team ID? You can get this from developer.apple.com.
+read devTeamID
+
+# Get the user's Org Identifier
+echo 2. What is your organisation identifier? e.g. com.developername
+read devOrgName
+
+echo Creating DeveloperSettings.xcconfig
+
+cat <<file >> DeveloperSettings.xcconfig
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = $devTeamID
+CODE_SIGN_STYLE = Automatic
+ORGANIZATION_IDENTIFIER = $devOrgName
+file
+
+echo Done! 


### PR DESCRIPTION
Add the ability to have local development settings in Xcode for different developer profiles. Update the README with instructions on updating for local building.

Add a setup file to generate the local Xcode config file for individual developers.

Add a Brewfile to easily setup swiftlint and sourcery.